### PR TITLE
Fix Google OAuth free-tier flow for modern Gemini CLI and new accounts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Türk finans piyasaları için AI agent - BIST, TEFAS, Kripto ve 
 authors = [{name = "Said Surucu"}]
 requires-python = ">=3.11"
 dependencies = [
-    "pydantic-ai>=0.0.14",
+    "pydantic-ai>=1.5,<2",
     "fastmcp>=2.11.0",
     "prompt-toolkit>=3.0.0",
     "python-dotenv>=1.1.1",

--- a/src/borsaci/cloudcode_provider.py
+++ b/src/borsaci/cloudcode_provider.py
@@ -137,6 +137,10 @@ class CloudCodeClient:
             )
 
             if not project_id:
+                # Account not onboarded yet - provision a managed project
+                project_id = await self._onboard_user(payload["metadata"])
+
+            if not project_id:
                 raise Exception(f"No project ID in response: {data}")
 
             self._project = CloudCodeProject(
@@ -144,6 +148,31 @@ class CloudCodeClient:
                 display_name=data.get("displayName"),
             )
             return self._project
+
+    async def _onboard_user(self, metadata: dict) -> Optional[str]:
+        """
+        Call onboardUser to provision a managed Code Assist project.
+
+        Required for accounts that have never used Gemini CLI / Code Assist.
+        The endpoint is a long-running operation; polled by re-posting until done.
+        """
+        access_token = await self._get_access_token()
+        session = await self._get_session()
+        url = f"{self._endpoint}:onboardUser"
+        headers = self._get_headers(access_token)
+        payload = {"tierId": "free-tier", "metadata": metadata}
+
+        for _ in range(10):
+            async with session.post(url, headers=headers, json=payload) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise Exception(f"onboardUser failed ({resp.status}): {text}")
+                data = await resp.json()
+                if data.get("done"):
+                    project = (data.get("response") or {}).get("cloudaicompanionProject") or {}
+                    return project.get("id")
+            await asyncio.sleep(2)
+        return None
 
     async def generate_content(
         self,
@@ -193,7 +222,7 @@ class CloudCodeClient:
         }
 
         # Retry logic for rate limiting (429 errors)
-        max_retries = 5
+        max_retries = 8
         for attempt in range(max_retries):
             async with session.post(url, headers=headers, json=payload) as resp:
                 if resp.status == 429:
@@ -213,6 +242,10 @@ class CloudCodeClient:
                                 break
                     except:
                         retry_delay = 1.0
+
+                    # Advertised retryDelay is often shorter than the real
+                    # throttle window on free tier - enforce exponential floor
+                    retry_delay = min(max(retry_delay, 2.0 * (2 ** attempt)), 45.0)
 
                     if attempt < max_retries - 1:
                         await asyncio.sleep(retry_delay + 0.1)  # Add small buffer

--- a/src/borsaci/oauth.py
+++ b/src/borsaci/oauth.py
@@ -90,6 +90,15 @@ def extract_from_gemini_cli() -> Optional[Tuple[str, Optional[str]]]:
             if result:
                 return result
 
+        # Modern Gemini CLI ships as bundled chunks (bundle/*.js) with named
+        # OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET constants
+        bundle_dir = gemini_dir / "bundle"
+        if bundle_dir.exists():
+            for chunk in sorted(bundle_dir.glob("*.js")):
+                result = _extract_credentials_from_bundle(chunk)
+                if result:
+                    return result
+
         # Recursive search as fallback (max 10 levels deep - OpenClaw pattern)
         for oauth_js in _find_oauth_files(gemini_dir, max_depth=10):
             result = _extract_credentials_from_file(oauth_js)
@@ -124,6 +133,25 @@ def _extract_credentials_from_file(file_path: Path) -> Optional[Tuple[str, Optio
             client_id = client_id_match.group(1)
             client_secret = client_secret_match.group(1) if client_secret_match else None
             return (client_id, client_secret)
+    except Exception:
+        pass
+    return None
+
+
+def _extract_credentials_from_bundle(file_path: Path) -> Optional[Tuple[str, Optional[str]]]:
+    """
+    Extract OAuth client ID/secret from a bundled Gemini CLI chunk file
+    using the named constants (OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET).
+    """
+    if not file_path.exists():
+        return None
+    try:
+        content = file_path.read_text(errors="ignore")
+        id_match = re.search(r'OAUTH_CLIENT_ID\s*=\s*["\']([^"\']+)["\']', content)
+        if not id_match:
+            return None
+        secret_match = re.search(r'OAUTH_CLIENT_SECRET\s*=\s*["\']([^"\']+)["\']', content)
+        return (id_match.group(1), secret_match.group(1) if secret_match else None)
     except Exception:
         pass
     return None


### PR DESCRIPTION
## Summary

Fixes the Google OAuth free-tier flow so BorsaCI works on a fresh machine with a modern Gemini CLI and a brand-new Google account. Reproduced on macOS with Gemini CLI 0.50.0 and a never-onboarded account; all three issues blocked startup before an OpenRouter key could be avoided.

## Problems & fixes

1. **`pydantic-ai` version incompatibility** — the loose `pydantic-ai>=0.0.14` constraint resolved to 2.x, where `MCPServerStreamableHTTP` no longer exists, so the app crashed on import. Pinned to `>=1.5,<2`.

2. **OAuth client not found in modern Gemini CLI** — the current Gemini CLI ships as bundled chunks (`bundle/*.js` with named `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` constants). The old `oauth2.js` layout no longer exists, so credential extraction silently fell back to the Antigravity client, which Google does not grant a managed free-tier project. Added a bundle scan to `extract_from_gemini_cli`.

3. **New accounts never get a project** — accounts that have never used Gemini CLI / Code Assist get no project from `loadCodeAssist`. Added an `onboardUser` call (free-tier) to `CloudCodeClient` that provisions a managed project, then proceeds.

4. **Rate-limit retry too shallow** — the advertised `retryDelay` is shorter than the real free-tier throttle window, so multi-task queries exhausted retries. Added an exponential backoff floor and raised max retries to 8.

## Testing

End-to-end verified against the live Borsa MCP server: `ASELS son 1 aylık mum grafik` planned a task, fetched 30 days of OHLCV data, validated, and produced a Turkish analysis + candlestick payload with no OpenRouter key configured (pure Google OAuth free tier).

## Notes

Only `pyproject.toml`, `src/borsaci/oauth.py`, and `src/borsaci/cloudcode_provider.py` are touched. No changes to the pre-existing hardcoded Antigravity fallback credentials in `oauth.py` — happy to move those to env vars in a follow-up if you'd prefer.
